### PR TITLE
Add sharing, state and conflate steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It enables you to chain together small, focused processing steps—such as mappi
 ## Features
 
 - **Composable Pipelines**: Chain multiple transformation steps (`then`) to process streams of data.
-- **Flexible Steps**: Includes mapping, buffering, and parallel ordered processing out-of-the-box.
+- **Flexible Steps**: Includes mapping, buffering, sharing, state handling, conflation and parallel ordered processing out-of-the-box.
 - **Kotlin Multiplatform**: Runs on JVM, Android, and iOS via Kotlin Multiplatform.
 - **Coroutine & Flow-based**: Naturally asynchronous and non-blocking.
 
@@ -18,12 +18,16 @@ import fipe.step.BufferedMapStep
 import fipe.step.ParallelOrderedStep
 import fipe.fipe
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.runBlocking
 
 fun main() = runBlocking {
     val pipeline = fipe<Int>()
         .then(MapStep { it * 2 })
         .then(BufferedMapStep(capacity = 10) { it + 1 })
+        .conflate()
+        .share(this)
+        .state(this, initialValue = 0)
         .then(ParallelOrderedStep { listOf(it, it + 1) })
 
     val input = flowOf(1, 2, 3, 4, 5)

--- a/fipe-core/src/commonMain/kotlin/fipe/step/ConflateStep.kt
+++ b/fipe-core/src/commonMain/kotlin/fipe/step/ConflateStep.kt
@@ -1,0 +1,18 @@
+package fipe.step
+
+import fipe.Fipe
+import fipe.Step
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.conflate
+
+interface ConflateStep<T> : Step<T, T>
+
+fun <T> ConflateStep(name: String = "ConflateStep"): ConflateStep<T> = ConflateStepImpl(name)
+
+fun <T> Fipe<T, T>.conflate(): Fipe<T, T> = this.then(ConflateStep())
+
+private class ConflateStepImpl<T>(
+    override val name: String,
+) : ConflateStep<T> {
+    override fun process(flow: Flow<T>): Flow<T> = flow.conflate()
+}

--- a/fipe-core/src/commonMain/kotlin/fipe/step/ShareStep.kt
+++ b/fipe-core/src/commonMain/kotlin/fipe/step/ShareStep.kt
@@ -1,0 +1,36 @@
+package fipe.step
+
+import fipe.Fipe
+import fipe.Step
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.shareIn
+
+interface ShareStep<T> : Step<T, T> {
+    val scope: CoroutineScope
+    val replay: Int
+    val started: SharingStarted
+}
+
+fun <T> ShareStep(
+    scope: CoroutineScope,
+    replay: Int = 0,
+    started: SharingStarted = SharingStarted.Eagerly,
+    name: String = "ShareStep",
+): ShareStep<T> = ShareStepImpl(scope, replay, started, name)
+
+fun <T> Fipe<T, T>.share(
+    scope: CoroutineScope,
+    replay: Int = 0,
+    started: SharingStarted = SharingStarted.Eagerly,
+): Fipe<T, T> = this.then(ShareStep(scope, replay, started))
+
+private class ShareStepImpl<T>(
+    override val scope: CoroutineScope,
+    override val replay: Int,
+    override val started: SharingStarted,
+    override val name: String,
+) : ShareStep<T> {
+    override fun process(flow: Flow<T>): Flow<T> = flow.shareIn(scope, started, replay)
+}

--- a/fipe-core/src/commonMain/kotlin/fipe/step/StateStep.kt
+++ b/fipe-core/src/commonMain/kotlin/fipe/step/StateStep.kt
@@ -1,0 +1,36 @@
+package fipe.step
+
+import fipe.Fipe
+import fipe.Step
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+
+interface StateStep<T> : Step<T, T> {
+    val scope: CoroutineScope
+    val started: SharingStarted
+    val initialValue: T
+}
+
+fun <T> StateStep(
+    scope: CoroutineScope,
+    started: SharingStarted = SharingStarted.Eagerly,
+    initialValue: T,
+    name: String = "StateStep",
+): StateStep<T> = StateStepImpl(scope, started, initialValue, name)
+
+fun <T> Fipe<T, T>.state(
+    scope: CoroutineScope,
+    started: SharingStarted = SharingStarted.Eagerly,
+    initialValue: T,
+): Fipe<T, T> = this.then(StateStep(scope, started, initialValue))
+
+private class StateStepImpl<T>(
+    override val scope: CoroutineScope,
+    override val started: SharingStarted,
+    override val initialValue: T,
+    override val name: String,
+) : StateStep<T> {
+    override fun process(flow: Flow<T>): Flow<T> = flow.stateIn(scope, started, initialValue)
+}

--- a/fipe-core/src/commonTest/kotlin/fipe/FipeTest.kt
+++ b/fipe-core/src/commonTest/kotlin/fipe/FipeTest.kt
@@ -4,8 +4,14 @@ import fipe.step.BufferedMapStep
 import fipe.step.MapStep
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -30,5 +36,47 @@ class FipeTest {
         val step = MapStep<Int, Int> { it * it }
         val result = step.process(flowOf(1, 2, 3)).toList()
         assertEquals(listOf(1, 4, 9), result)
+    }
+
+    @Test
+    fun `share step shares upstream in pipeline`() = runTest {
+        var count = 0
+        val pipeline = fipe<Int>()
+            .share(this, started = SharingStarted.Lazily)
+        val input = flow {
+            count++
+            emit(1)
+        }
+        val shared = pipeline.toFlow(input)
+        shared.first()
+        shared.first()
+        assertEquals(1, count)
+    }
+
+    @Test
+    fun `state step exposes latest value`() = runTest {
+        val pipeline = fipe<Int>()
+            .state(this, started = SharingStarted.Eagerly, initialValue = 0)
+        val state = pipeline.toFlow(flowOf(1, 2, 3)) as StateFlow<Int>
+        val values = state.take(4).toList()
+        assertEquals(listOf(0, 1, 2, 3), values)
+        assertEquals(3, state.value)
+    }
+
+    @Test
+    fun `conflate step drops intermediate values`() = runTest {
+        val pipeline = fipe<Int>().conflate()
+        val result = mutableListOf<Int>()
+        pipeline.toFlow(
+            flow {
+                emit(1)
+                emit(2)
+                emit(3)
+            }
+        ).collect {
+            result.add(it)
+            if (it == 1) delay(10)
+        }
+        assertEquals(listOf(1, 3), result)
     }
 }


### PR DESCRIPTION
## Summary
- add `ShareStep`, `StateStep`, and `ConflateStep`
- expose `.share`, `.state`, and `.conflate` extensions on `Fipe`
- update README with new features and example
- test new steps